### PR TITLE
Double sent events after 30 mins are ignored

### DIFF
--- a/src/messageHandler.ts
+++ b/src/messageHandler.ts
@@ -46,7 +46,11 @@ export const handleMessage = async (
   message: Message | PartialMessage,
   client: Client,
 ) => {
-  if (message.author?.id !== '1242388858897956906') return;
+  if (
+    message.author?.id !== '1242388858897956906' ||
+    Date.now() - message.createdTimestamp > 1000 * 60 * 2.5
+  )
+    return;
   await handleTimers(message, client);
   if (
     message.embeds.length > 0 &&


### PR DESCRIPTION
Discord quirk:
Rapidfires old event after 15 to 120 minutes later, this filters them